### PR TITLE
Add new features, and clean up nested variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Review the variables as shown in defaults.
 You can add a firewall definition to the variables for your host (../host_vars/[host_name].yaml), group of hosts (../group_vars/[group_name].yaml) using the following structure (see molecule.default.vars/test.yaml for an example):
 
 ```
+# this variable point to the rules that are pushed to the remote host
+# it is a dict of tables, with chain, with rules, see molecule/default/vars/test.yaml
 nftables_ruleset:
-
-  # firewall family and name"
+  # keys of this become tables
+  # they must be:
+  # firewall family and name, e.g."
   "inet firewall":
 
     # description of the table
-    desc: "firewall of device"
+    comment: "firewall of device"
 
     chains:
 
@@ -34,12 +37,16 @@ nftables_ruleset:
         - ...
 
   # another table with the same structure
+  # valid families are things like inet, inet6, netdev, and inet,
+  # see nftables docs for the full reference
   "inet foo":
 
-# the rules here ....
+# the potential rules are defined under `nftables_rules`
 # every rule has two attributes:
-# def: the definition of the rules or set of rules in valid nftables syntax
-# depends_on: optional list of dependencies of variables from nftables_variables
+# -> def: the definition of the rules or set of rules in valid nftables syntax
+# -> depends_on: optional list of dependencies of variables from nftables_variables
+# see molecule/default/vars/test.yaml for an example
+
 nftables_rules:
   input_hook: >
     type filter hook input priority 0; policy drop;
@@ -53,20 +60,22 @@ nftables_rules:
         ct state new accept
 
 
+# these are the variable definition, which are included with depends_on
+# make sure the keys match
+# see molecule/default/vars/test.yaml for an example
 nftables_variables:
   header:
-    note: this is a simple firewall, for ipv4 and ipv6
+    comment: this is a simple firewall, for ipv4 and ipv6
     def: "# built by me :)"
 
   tcp_ports:
-    note: tcp ports configuration
+    comment: tcp ports configuration
     def: |
       {% if nftables_open_tcp_ports_global %}define OPEN_TCP_PORTS = { {{ nftables_open_tcp_ports_global | join(",") }} }{% endif +%}
       {% if nftables_open_tcp_ports_local %}define LOCAL_OPEN_TCP_PORTS = { {{ nftables_open_tcp_ports_local | join(",") }} }{% endif +%}
       {% if nftables_open_tcp_ports_vpn %}define VPN_TCP_PORTS = { {{ nftables_open_tcp_ports_vpn | join(",") }} }{% endif +%}
 
-  ... (see defaults/main.yaml)
-
+  ...
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,22 +37,20 @@ nftables_ruleset:
   "inet foo":
 
 # the rules here ....
+# every rule has two attributes:
+# def: the definition of the rules or set of rules in valid nftables syntax
+# depends_on: optional list of dependencies of variables from nftables_variables
 nftables_rules:
   input_hook: >
     type filter hook input priority 0; policy drop;
-  valid_connections: |
-    ct state established, related accept
-    ct state invalid drop
+  valid_connections:
+    def: |
+        ct state established, related accept
+        ct state invalid drop
 
-  new_connections: |
-    ct state new accept
-  ... (see defaults/main.yaml)
-  ...
-
-
-nftables_loaded_variables:
-  - header
-  ... (see defaults/main.yaml)
+  new_connections:
+    def: |
+        ct state new accept
 
 
 nftables_variables:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ roles:
 - copy a nftables template to nftables directory
 - edit nftables service to point to our new main file
 - create script to reload firewall, which dumps tables outside of our control to files, and reloads the firewall after
-- when abuseip_api_key is defined, add a script to pull the blocklist using their api, and make that a systemd service
+- when nftables_abuseip_api_key is defined, add a script to pull the blocklist using their api, and make that a systemd service
 - enable nftable service when requested
 - uninstall iptables when requested
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -17,7 +17,6 @@ nftables_open_udp_ports_vpn: []
 
 nftables_ruleset: {}
 nftables_rules: {}
-nftables_loaded_variables: {}
 nftables_variables: {}
 nftables_dynamic_tables: {}
 nftables_sets: {}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -4,7 +4,7 @@ nftables_script_folder: /usr/local/bin
 nftables_uninstall_iptables: false
 nftables_enable_filter_sets: true
 nftables_enable_service: false
-abuseip_api_key: ""
+nftables_abuseip_api_key: ""
 
 nftables_open_tcp_ports_global:
   - ssh

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -15,6 +15,7 @@ class FilterModule:
             "multiline_indent": self.multiline_indent,
             "strip_family": self.strip_family,
             "get_rule_names": self.get_rule_names,
+            "get_rule_dependencies": self.get_rule_dependencies,
         }
 
     def is_list(self, obj):
@@ -59,3 +60,30 @@ class FilterModule:
         all_rules = list(itertools.chain(*all_rules))
 
         return all_rules
+
+    def get_rule_dependencies(self, obj, all_rules):
+        """get rule potential rule dependencies from nested nftables yaml"""
+
+        if isinstance(obj, AnsibleUndefined):
+            return []
+
+        elif not isinstance(obj, dict):
+            raise AnsibleFilterError("This only works on dict")
+
+        dependencies = []
+
+        for table in obj:
+            for _, rules in obj[table].get("chains").items():
+                for rule in rules:
+                    current_rule = all_rules[rule]
+                    if rule_dependencies := current_rule.get("depends_on"):
+                        if not isinstance(rule_dependencies, list):
+                            raise AnsibleFilterError(
+                                "dependency for %s should be list", rule
+                            )
+
+                        for dep in rule_dependencies:
+                            dependencies.append(dep)
+
+        # return deduplicated dependencies
+        return list(set(dependencies))

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -70,7 +70,7 @@ class FilterModule:
         elif not isinstance(obj, dict):
             raise AnsibleFilterError("This only works on dict")
 
-        dependencies = []
+        dependencies = set()
 
         for table in obj:
             for _, rules in obj[table].get("chains").items():
@@ -83,7 +83,8 @@ class FilterModule:
                             )
 
                         for dep in rule_dependencies:
-                            dependencies.append(dep)
+                            if dep not in dependencies:
+                                dependencies.add(dep)
 
         # return deduplicated dependencies
-        return list(set(dependencies))
+        return list(dependencies)

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -70,12 +70,17 @@ class FilterModule:
         elif not isinstance(obj, dict):
             raise AnsibleFilterError("This only works on dict")
 
-        dependencies = set()
+        # cannot use set here as we need
+        # fixed variable order to stay idempotent
+        dependencies = []
 
+        # iterate over structure
+        # getting the value of the rules specified
         for table in obj:
             for _, rules in obj[table].get("chains").items():
                 for rule in rules:
                     current_rule = all_rules[rule]
+
                     if rule_dependencies := current_rule.get("depends_on"):
                         if not isinstance(rule_dependencies, list):
                             raise AnsibleFilterError(
@@ -84,7 +89,6 @@ class FilterModule:
 
                         for dep in rule_dependencies:
                             if dep not in dependencies:
-                                dependencies.add(dep)
+                                dependencies.append(dep)
 
-        # return deduplicated dependencies
-        return list(dependencies)
+        return dependencies

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -21,3 +21,13 @@
   when: nftables_enable_service
   become: true
   listen: enable nftables service
+
+- name: Enable update-abuseip-blocklist timer
+  ansible.builtin.systemd:
+    name: update-abuseip-blocklist.timer
+    state: started
+    enabled: true
+    daemon_reload: true
+  become: true
+  ignore_errors: "{{ ansible_check_mode }}"
+  listen: "enable abuseip-blocklist timer"

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -126,18 +126,6 @@ argument_specs:
         default: {}
         description: list of nftables variables that exist
 
-      nftables_loaded_variables:
-        type: list
-        elements: str
-        default:
-          - header
-          - interface
-          - local_network
-          - tcp_ports
-          - udp_ports
-        required: false
-        description: list of variables that are loaded and passed to templates
-
       nftables_ruleset:
         type: dict
         default:

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -59,7 +59,7 @@ argument_specs:
         required: false
         description: whether to enable the nftables systemd services
 
-      abuseip_api_key:
+      nftables_abuseip_api_key:
         type: str
         default: ""
         required: false

--- a/molecule/default/tests/test_result.py
+++ b/molecule/default/tests/test_result.py
@@ -8,17 +8,19 @@ def test_os_release(host):
 
 
 def test_nft_present(host):
-    """test ssh ssh_known_hosts file has been created,
-    with the requested key types"""
+    """test that the nft binary is present on the system"""
 
     assert host.run("which nft").rc == 0
 
 
-def test_nft_table_firewall(host):
-    """test ssh ssh_known_hosts file has been created,
-    with the requested key types"""
+def test_nft_tables_present(host):
+    """test that the nft firewall table has been created"""
 
-    assert host.run("nft list tables").contains("inet firewall")
+    with host.sudo():
+        output = host.check_output("nft list tables")
+
+    assert "inet firewall" in output
+    assert "inet blocklist" in output
 
 
 def nftables_abuseip_service(host):
@@ -26,6 +28,7 @@ def nftables_abuseip_service(host):
 
     assert host.file("/usr/local/bin/manage_nft_abuseip_blocklist.py")
     assert host.service("update-abuseip-blocklist.timer").is_running
+    assert host.service("update-abuseip-blocklist.timer").is_enabled
 
 
 def test_table_files_created(host):

--- a/molecule/default/tests/test_result.py
+++ b/molecule/default/tests/test_result.py
@@ -12,3 +12,25 @@ def test_nft_present(host):
     with the requested key types"""
 
     assert host.run("which nft").rc == 0
+
+
+def test_nft_table_firewall(host):
+    """test ssh ssh_known_hosts file has been created,
+    with the requested key types"""
+
+    assert host.run("nft list tables").contains("inet firewall")
+
+
+def nftables_abuseip_service(host):
+    """test that the correct table files are created"""
+
+    assert host.file("/usr/local/bin/manage_nft_abuseip_blocklist.py")
+    assert host.service("update-abuseip-blocklist.timer").is_running
+
+
+def test_table_files_created(host):
+    """test that the correct table files are created"""
+
+    with host.sudo():
+        assert host.file("/etc/nftables/firewall.nft")
+        assert host.file("/etc/nftables/defines.nft")

--- a/molecule/default/vars/test.yaml
+++ b/molecule/default/vars/test.yaml
@@ -1,13 +1,6 @@
 ---
 systemd_failmail_email: "foo@example.com"
 
-nftables_loaded_variables:
-  - header
-  - interface
-  - local_network
-  - tcp_ports
-  - udp_ports
-
 # rules put into chains
 nftables_ruleset:
   "inet firewall":
@@ -27,43 +20,54 @@ nftables_dynamic_tables: {}
 # some rules were inspired on:
 # https://github.com/yoramvandevelde/nftables-example/blob/master/nftables-init.rules
 nftables_rules:
-  input_hook: >
-    type filter hook input priority 0; policy drop;
-  valid_connections: |
-    ct state established, related accept
-    ct state invalid drop
+  input_hook:
+    def: type filter hook input priority 0; policy drop;
+  valid_connections:
+    def: |
+      ct state established, related accept
+      ct state invalid drop
 
-  new_connections: |
-    ct state new accept
+  new_connections:
+    def: ct state new accept
 
-  loopback: |
-    iif != lo ip  daddr 127.0.0.1/8 counter drop comment "drop fake loopback"
-    iif != lo ip6 daddr ::1/128     counter drop
-    meta iifname lo accept
+  loopback:
+    def: |
+      iif != lo ip  daddr 127.0.0.1/8 counter drop comment "drop fake loopback"
+      iif != lo ip6 daddr ::1/128     counter drop
+      meta iifname lo accept
 
-  drop_tcp_fragments: |
-    # Drop all fragments.
-    ip frag-off & 0x1fff != 0 counter drop
+  drop_tcp_fragments:
+    def: |
+      ip frag-off & 0x1fff != 0 counter drop comment "Drop all fragments"
 
-  icmp: >-
-    ip protocol icmp icmp type { destination-unreachable, echo-reply, echo-request, time-exceeded } limit rate 10/second burst 2 packets accept
-  icmpv6: >-
-    ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, echo-reply, echo-request, packet-too-big, parameter-problem, time-exceeded } limit rate 10/second burst 2 packets accept
-  globally_allowed_tcp: |
-    iifname $WAN_IF tcp dport $OPEN_TCP_PORTS ct state new accept
+  icmp:
+    def: >-
+      ip protocol icmp icmp type { destination-unreachable, echo-reply, echo-request, time-exceeded } limit rate 10/second burst 2 packets accept
 
-  globally_allowed_udp: |
-    iifname $WAN_IF udp dport $OPEN_UDP_PORTS ct state new accept
+  icmpv6:
+    def: >-
+      ip6 nexthdr icmpv6 icmpv6 type { destination-unreachable, echo-reply, echo-request, packet-too-big, parameter-problem, time-exceeded } limit rate 10/second burst 2 packets accept
 
-  locally_allowed_tcp: |
-    ip  saddr $LOCAL_IPV4_RANGE ip  daddr $ASSIGNED_IPV4_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
-    ip6 saddr $LOCAL_IPV6_RANGE ip6 daddr $ASSIGNED_IPV6_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
+  globally_allowed_tcp:
+    def: |
+      iifname $WAN_IF tcp dport $OPEN_TCP_PORTS ct state new accept
+    depends_on:
+      - tcp_ports
+
+  globally_allowed_udp:
+    def: |
+      iifname $WAN_IF udp dport $OPEN_UDP_PORTS ct state new accept
+    depends_on:
+      - udp_ports
+
+  locally_allowed_tcp:
+    def: |
+      ip  saddr $LOCAL_IPV4_RANGE ip  daddr $ASSIGNED_IPV4_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
+      ip6 saddr $LOCAL_IPV6_RANGE ip6 daddr $ASSIGNED_IPV6_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
+    depends_on:
+      - local_network
 
 nftables_variables:
-  header:
-    note: this is a simple firewall, for ipv4 and ipv6
-    def: "# built by me :)"
-
   tcp_ports:
     note: tcp ports configuration
     def: |

--- a/molecule/default/vars/test.yaml
+++ b/molecule/default/vars/test.yaml
@@ -1,5 +1,6 @@
 ---
 systemd_failmail_email: "foo@example.com"
+nftables_abuseip_api_key: "<< API KEY HERE >>"
 
 # rules put into chains
 nftables_ruleset:
@@ -14,8 +15,6 @@ nftables_ruleset:
         - icmp
         - icmpv6
         - globally_allowed_tcp
-
-nftables_dynamic_tables: {}
 
 # some rules were inspired on:
 # https://github.com/yoramvandevelde/nftables-example/blob/master/nftables-init.rules

--- a/molecule/default/vars/test.yaml
+++ b/molecule/default/vars/test.yaml
@@ -53,19 +53,21 @@ nftables_rules:
       iifname $WAN_IF tcp dport $OPEN_TCP_PORTS ct state new accept
     depends_on:
       - tcp_ports
+      - interface
 
   globally_allowed_udp:
     def: |
       iifname $WAN_IF udp dport $OPEN_UDP_PORTS ct state new accept
     depends_on:
       - udp_ports
+      - interface
 
   locally_allowed_tcp:
     def: |
       ip  saddr $LOCAL_IPV4_RANGE ip  daddr $ASSIGNED_IPV4_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
       ip6 saddr $LOCAL_IPV6_RANGE ip6 daddr $ASSIGNED_IPV6_RANGE tcp dport $LOCAL_OPEN_TCP_PORTS accept
     depends_on:
-      - local_network
+      - local_range
 
 nftables_variables:
   tcp_ports:
@@ -82,7 +84,7 @@ nftables_variables:
       {% if nftables_open_udp_ports_local %}define LOCAL_OPEN_UDP_PORTS = { {{ nftables_open_udp_ports_local | join(",") }} }{% endif +%}
       {% if nftables_open_udp_ports_vpn %}define VPN_UDP_PORTS = { {{ nftables_open_udp_ports_vpn | join(",") }} }{% endif +%}
 
-  local_network:
+  local_range:
     comment: local ranges in ipv4/ipv6
     def: |
       define LOCAL_IPV4_RANGE = { 10.0.0.0/8, 127.16.0.1/12, 192.168.0.0/16 }

--- a/molecule/default/vars/test.yaml
+++ b/molecule/default/vars/test.yaml
@@ -4,7 +4,7 @@ systemd_failmail_email: "foo@example.com"
 # rules put into chains
 nftables_ruleset:
   "inet firewall":
-    desc: "firewall of device"
+    comment: "firewall of device"
     chains:
       input:
         - input_hook
@@ -69,27 +69,27 @@ nftables_rules:
 
 nftables_variables:
   tcp_ports:
-    note: tcp ports configuration
+    comment: tcp ports configuration
     def: |
       {% if nftables_open_tcp_ports_global %}define OPEN_TCP_PORTS = { {{ nftables_open_tcp_ports_global | join(",") }} }{% endif +%}
       {% if nftables_open_tcp_ports_local %}define LOCAL_OPEN_TCP_PORTS = { {{ nftables_open_tcp_ports_local | join(",") }} }{% endif +%}
       {% if nftables_open_tcp_ports_vpn %}define VPN_TCP_PORTS = { {{ nftables_open_tcp_ports_vpn | join(",") }} }{% endif +%}
 
   udp_ports:
-    note: udp ports configuration
+    comment: udp ports configuration
     def: |
       {% if nftables_open_udp_ports_global %}define OPEN_UDP_PORTS = { {{ nftables_open_udp_ports_global | join(",") }} }{% endif +%}
       {% if nftables_open_udp_ports_local %}define LOCAL_OPEN_UDP_PORTS = { {{ nftables_open_udp_ports_local | join(",") }} }{% endif +%}
       {% if nftables_open_udp_ports_vpn %}define VPN_UDP_PORTS = { {{ nftables_open_udp_ports_vpn | join(",") }} }{% endif +%}
 
   local_network:
-    note: local ranges in ipv4/ipv6
+    comment: local ranges in ipv4/ipv6
     def: |
       define LOCAL_IPV4_RANGE = { 10.0.0.0/8, 127.16.0.1/12, 192.168.0.0/16 }
       define LOCAL_IPV6_RANGE = { ::1/128 }
 
   interface:
-    note: define public interface
+    comment: define public interface
     def: |
       define WAN_IF = "eth0"
 

--- a/tasks/abuseipdb/blocklist.yaml
+++ b/tasks/abuseipdb/blocklist.yaml
@@ -50,12 +50,33 @@
         chdir: "/lib/systemd"
       changed_when: false
       become: true
+      notify:
+        - enable abuseip-blocklist timer
 
-- name: Enable update-abuseip-blocklist timer
-  ansible.builtin.systemd:
-    name: update-abuseip-blocklist.timer
-    state: started
-    enabled: true
-    daemon_reload: true
-  become: true
-  ignore_errors: "{{ ansible_check_mode }}"
+- name: Create blocklist in nft as table and file
+  block:
+    - name: Create blocklist table when it does not exist in nft
+      ansible.builtin.command: "nft add table blocklist"
+      become: true
+      changed_when: true
+      when: not table in nft_table_names
+      tags:
+        - nftables_setup
+
+    - name: Create blocklist as empty table if it does not exist in nft
+      ansible.builtin.template:
+        src: abuseipdb/blocklist.nft.j2
+        dest: "{{ nftables_dir }}/blocklist.nft"
+        mode: u=rw,g=r,o=
+      # crashes on validation due to dependencies,
+      # gets validated as a whole when global file is pushed
+      # validate: /usr/sbin/nft -c -f %s
+      become: true
+      # when table just got created
+      when: not "inet blocklist" in nft_table_names
+      tags:
+        - nftables_setup
+      notify:
+        - reload nftables ruleset
+        - start nftables service
+        - enable nftables service

--- a/tasks/abuseipdb/blocklist.yaml
+++ b/tasks/abuseipdb/blocklist.yaml
@@ -13,7 +13,6 @@
     group: root
     mode: u=rwx,g=rx,o=x
   become: true
-  when: abuseip_api_key is defined
 
 - name: Make systemd services for update-abuseip-blocklist
   block:

--- a/tasks/abuseipdb/blocklist.yaml
+++ b/tasks/abuseipdb/blocklist.yaml
@@ -58,7 +58,7 @@
       ansible.builtin.command: "nft add table blocklist"
       become: true
       changed_when: true
-      when: not 'blocklist' in nft_table_names
+      when: not "inet blocklist" in nft_table_names
       tags:
         - nftables_setup
 

--- a/tasks/abuseipdb/blocklist.yaml
+++ b/tasks/abuseipdb/blocklist.yaml
@@ -59,7 +59,7 @@
       ansible.builtin.command: "nft add table blocklist"
       become: true
       changed_when: true
-      when: not table in nft_table_names
+      when: not 'blocklist' in nft_table_names
       tags:
         - nftables_setup
 

--- a/tasks/assert/assert_rules.yaml
+++ b/tasks/assert/assert_rules.yaml
@@ -12,17 +12,3 @@
   delegate_to: localhost
   run_once: true
   loop: "{{ nftables_ruleset | get_rule_names }}"
-
-- name: Verify that all required rule variables are defined
-  ansible.builtin.assert:
-    that:
-      - "nftables_variables.{{ item }} is defined"
-      - "nftables_variables.{{ item }} | length > 0"
-      - "nftables_variables.{{ item }} != None"
-    fail_msg: "{{ item }} needs to be set for the role to work"
-    success_msg: "Required variable {{ item }} is defined"
-  changed_when: false
-  delegate_to: localhost
-  run_once: true
-  diff: false
-  loop: "{{ nftables_loaded_variables }}"

--- a/tasks/assert/assert_vars.yaml
+++ b/tasks/assert/assert_vars.yaml
@@ -1,18 +1,14 @@
 ---
-- name: Verify that required variables are defined
+- name: Verify that all required rule variables are defined
   ansible.builtin.assert:
     that:
-      - "{{ item }} is defined"
-      - "{{ item }} | length > 0"
-      - "{{ item }} != None"
+      - "nftables_variables.{{ item }} is defined"
+      - "nftables_variables.{{ item }} | length > 0"
+      - "nftables_variables.{{ item }} != None"
     fail_msg: "{{ item }} needs to be set for the role to work"
     success_msg: "Required variable {{ item }} is defined"
   changed_when: false
-  diff: false
   delegate_to: localhost
   run_once: true
-  loop:
-    - nftables_ruleset
-    - nftables_dir
-    - nftables_script_folder
-    - nftables_loaded_variables
+  diff: false
+  loop: "{{ _nftables_required_variables }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,12 +1,4 @@
 ---
-- name: Check that required passed variables are defined
-  ansible.builtin.include_tasks:
-    file: assert/assert_vars.yaml
-  tags:
-    - nftables_setup
-    - nftables_update
-    - nftables_install
-
 - name: Assert rules are properly defined
   ansible.builtin.include_tasks:
     file: assert/assert_rules.yaml
@@ -15,6 +7,18 @@
         - nftables_setup
         - nftables_update
         - nftables_install
+
+- name: Get required variables from rules dependencies
+  ansible.builtin.set_fact:
+    _nftables_required_variables: "{{ nftables_ruleset | get_rule_dependencies(nftables_rules) }}"
+
+- name: Check that required passed variables are defined
+  ansible.builtin.include_tasks:
+    file: assert/assert_vars.yaml
+  tags:
+    - nftables_setup
+    - nftables_update
+    - nftables_install
 
 - name: Install nftables and requirements for this role
   ansible.builtin.package:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -53,6 +53,14 @@
     - nftables_setup
     - nftables_update
 
+- name: Create abuseipdb based blocklist (when abuseipdb key is passed)
+  ansible.builtin.include_tasks:
+    file: abuseipdb/blocklist.yaml
+    apply:
+      tags:
+        - nftables_setup
+  when: nftables_abuseip_api_key
+
 - name: Create requested nft tables (in memory)
   ansible.builtin.include_tasks:
     file: nft/create_nft_tables.yaml
@@ -96,14 +104,6 @@
   become: true
   tags:
     - nftables_setup
-
-- name: Create abuseipdb based blocklist
-  ansible.builtin.include_tasks:
-    file: abuseipdb/blocklist.yaml
-    apply:
-      tags:
-        - nftables_setup
-  when: abuseip_api_key
 
 - name: Uninstall iptables if present
   ansible.builtin.package:

--- a/tasks/nft/create_nft_tables.yaml
+++ b/tasks/nft/create_nft_tables.yaml
@@ -15,7 +15,7 @@
   become: true
   changed_when: true
   when: not table in nft_table_names
-  loop: "{{ nftables_dynamic_tables.keys() | list + ['inet blocklist'] }}"
+  loop: "{{ nftables_dynamic_tables.keys() | list }}"
   loop_control:
     loop_var: table
   tags:

--- a/tasks/table_files/create_tables.yaml
+++ b/tasks/table_files/create_tables.yaml
@@ -37,24 +37,6 @@
     - nftables_update
   when: nftables_dynamic_tables
 
-- name: Create blocklist as empty table if it does not exist in nft
-  ansible.builtin.template:
-    src: abuseipdb/blocklist.nft.j2
-    dest: "{{ nftables_dir }}/blocklist.nft"
-    mode: u=rw,g=r,o=
-  # crashes on validation due to dependencies,
-  # gets validated as a whole when global file is pushed
-  # validate: /usr/sbin/nft -c -f %s
-  become: true
-  # when table just got created
-  when: not "inet blocklist" in nft_table_names
-  tags:
-    - nftables_setup
-  notify:
-    - reload nftables ruleset
-    - start nftables service
-    - enable nftables service
-
 - name: Copy all template nft files
   ansible.builtin.template:
     src: tables/table.nft.j2

--- a/templates/abuseipdb/blocklist.nft.j2
+++ b/templates/abuseipdb/blocklist.nft.j2
@@ -1,4 +1,5 @@
 #!/usr/sbin/nft -f
+# {{ ansible_managed | comment }}
 # managed by script
 # manage_nft_abuseip_blocklist.py
 

--- a/templates/abuseipdb/manage_nft_abuseip_blocklist.py.j2
+++ b/templates/abuseipdb/manage_nft_abuseip_blocklist.py.j2
@@ -8,6 +8,7 @@ import logging
 import subprocess
 import sys
 
+import jinja2
 import requests
 from jinja2 import Template
 

--- a/templates/abuseipdb/manage_nft_abuseip_blocklist.py.j2
+++ b/templates/abuseipdb/manage_nft_abuseip_blocklist.py.j2
@@ -2,19 +2,21 @@
 
 {{ ansible_managed | comment }}
 
-import nftables
-import subprocess
-import json
 import ipaddress
-from jinja2 import Template
-import requests
-import sys
+import json
 import logging
+import subprocess
+import sys
+
+import requests
+from jinja2 import Template
+
+import nftables
 
 logging.basicConfig(level='INFO')
 logger = logging.getLogger(name=None)
 
-ABUSE_IP_API_KEY = "{{ abuseip_api_key }}"
+ABUSE_IP_API_KEY = "{{ nftables_abuseip_api_key }}"
 
 # template of blocklist
 {% raw %}

--- a/templates/nftables.nft.j2
+++ b/templates/nftables.nft.j2
@@ -10,23 +10,21 @@ include "{{ nftables_dir }}/defines.nft"
 
 # Static tables
 {% for table, contents in nftables_ruleset.items() %}
-{%- if contents.desc is defined %}
-# {{ contents.desc }}
+{%- if contents.comment is defined %}
+# {{ contents.comment }}
 {% endif %}
 include "{{ nftables_dir }}/{{ table | strip_family }}.nft"
 
 {% endfor %}
-{% if abuseip_api_key %}
+{% if nftables_abuseip_api_key %}
 # ipv4/ipv6 blocklist of bad reputation IPs
 include "{{ nftables_dir}}/blocklist.nft"
 {% endif %}
 # Dynamic tables
 {% for table, contents in nftables_dynamic_tables.items() %}
-{%- if contents.desc is defined %}
-# {{ contents.desc }}
+{%- if contents.comment is defined %}
+# {{ contents.comment }}
 {% endif %}
 include "{{ nftables_dir }}/{{ table | split(' ') | join('_') }}.nft"
 
 {% endfor %}
-
-

--- a/templates/nftables.nft.j2
+++ b/templates/nftables.nft.j2
@@ -16,9 +16,10 @@ include "{{ nftables_dir }}/defines.nft"
 include "{{ nftables_dir }}/{{ table | strip_family }}.nft"
 
 {% endfor %}
+{% if abuseip_api_key %}
 # ipv4/ipv6 blocklist of bad reputation IPs
 include "{{ nftables_dir}}/blocklist.nft"
-
+{% endif %}
 # Dynamic tables
 {% for table, contents in nftables_dynamic_tables.items() %}
 {%- if contents.desc is defined %}

--- a/templates/tables/defines.nft.j2
+++ b/templates/tables/defines.nft.j2
@@ -2,8 +2,8 @@
 {{ ansible_managed | comment }}
 
 # Defined variables
-{% for variable in nftables_loaded_variables %}
-# {{ nftables_variables[variable].note }}
+{% for variable in _nftables_required_variables %}
+# {{ nftables_variables[variable].comment }}
 {{ nftables_variables[variable].def }}
 
 {% endfor %}

--- a/templates/tables/empty.nft.j2
+++ b/templates/tables/empty.nft.j2
@@ -3,4 +3,3 @@
 
 table {{ table }} {
 }
-

--- a/templates/tables/table.nft.j2
+++ b/templates/tables/table.nft.j2
@@ -1,8 +1,8 @@
 #!/usr/sbin/nft -f
 {{ ansible_managed | comment }}
 
-{% if nftables_ruleset[table].desc is defined -%}
-# {{ nftables_ruleset[table].desc }}
+{% if nftables_ruleset[table].comment is defined -%}
+# {{ nftables_ruleset[table].comment }}
 {% endif %}
 table {{ table }} {
 {% if nftables_enable_filter_sets and table == "inet firewall" %}
@@ -13,10 +13,10 @@ table {{ table }} {
     chain {{ chain }} {
 
 {% for chain_rule in chain_rules %}
-{%- if nftables_rules[chain_rule] | is_list %}
-{{ nftables_rules[chain_rule] | multiline_indent(indent=8) }}
+{%- if nftables_rules[chain_rule].def | is_list %}
+{{ nftables_rules[chain_rule].def | multiline_indent(indent=8) }}
 {% else %}
-{{ nftables_rules[chain_rule] | indent(width=8, first=True) }}
+{{ nftables_rules[chain_rule].def | indent(width=8, first=True) }}
 {% endif -%}
 {% endfor %}
     }


### PR DESCRIPTION
This PR:
- moves `note` and `desc` both to the more general and clearer `comment`
- moves the push to the blocklist forward, and make the role function properly when no abuseip_api_key is defined
- it moves all vars to be prefixed by `nftables_`
- removes `nftables_loaded_variables` and makes it inferred based on a `depends_on` list per rule.
	- a custom filter was added to facilitate this
	- logic order in assertion
- adds additional tests to ensure role functions properly
	
This has breaking changes in variable naming.